### PR TITLE
fix: search bar protection

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,11 +2,13 @@
 
 import React, { useEffect, useState } from "react";
 import { getAuth, onAuthStateChanged, User } from "firebase/auth";
+import { useRouter } from "next/navigation";
 
 export default function Dashboard() {
     const [user, setUser] = useState<User | null>(null);
     const [token, setToken] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
+    const router = useRouter();
 
     const auth = getAuth();
 
@@ -19,13 +21,14 @@ export default function Dashboard() {
                 setToken(idToken);
             } else {
                 setToken(null);
+                router.push("/authentication?toast=not-signed-in");
             }
 
             setLoading(false);
         });
 
         return () => unsubscribe();
-    }, [auth]);
+    }, [auth, router]);
 
     const refreshToken = async () => {
         if (!user) return;

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,12 +3,37 @@
 
 import Navbar from "@/components/navigation/navBar";
 import Sidebar from "@/components/navigation/sideBar";
+import { useAuth } from "@/contexts/authContext";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import LoadingSpinner from "@/components/LoadingSpinner";
 
 export default function AppLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const { userLoggedIn, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !userLoggedIn) {
+      router.push("/authentication?toast=not-signed-in");
+    }
+  }, [loading, userLoggedIn, router]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-black">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (!userLoggedIn) {
+    return null;
+  }
+
   return (
     <div className="min-h-screen flex flex-col">
       {/* Top Navbar */}


### PR DESCRIPTION
## What changed
- Not allowing users to access auth required pages by injecting "/dashboard" and such

## Why
- needed for website protection and security

## How to test
1. go to the login/signup page
2. dont login
3. try to inject "/dashboard" into search bar
4. it *should* throw you back to login page

## Screenshots (UI changes)
- N/A

## Checklist
- [ ] PR title is conventional (feat:, fix:, chore:, docs:)
- [ ] Tested locally
- [ ] No secrets/credentials logged or committed
- [ ] This PR is reasonably sized (if large, explained why)

## Notes for reviewers
- 
