### PR TITLE
Fix: onboarding routing, profanity filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@types/react-scroll": "^1.8.10",
+        "bad-words": "^4.0.0",
         "browser-image-compression": "^2.0.2",
         "firebase": "^12.3.0",
         "lucide-react": "^0.539.0",
@@ -2992,6 +2993,24 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/bad-words": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-4.0.0.tgz",
+      "integrity": "sha512-fLjG/I0N3I7xhurqGnGitSRD10UeEE63a7hyXtutQDpxo4+Eal+i7veWeZxZJPNtsl6X1mUIoWPwt8gQ7NMQUw==",
+      "license": "MIT",
+      "dependencies": {
+        "badwords-list": "^2.0.1-4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/badwords-list": {
+      "version": "2.0.1-4",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-2.0.1-4.tgz",
+      "integrity": "sha512-FxfZUp7B9yCnesNtFQS9v6PvZdxTYa14Q60JR6vhjdQdWI4naTjJIyx22JzoER8ooeT8SAAKoHLjKfCV7XgYUQ==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@types/react-scroll": "^1.8.10",
+    "bad-words": "^4.0.0",
     "browser-image-compression": "^2.0.2",
     "firebase": "^12.3.0",
     "lucide-react": "^0.539.0",

--- a/src/app/authentication/page.tsx
+++ b/src/app/authentication/page.tsx
@@ -11,7 +11,6 @@ import PasswordInput from "@/components/forms/PasswordInput";
 import {useToast} from "@/components/ui/ToastProvider";
 import {getAuthErrorMessage} from "@/utils/authErrors";
 import { ActivityPing } from "@/utils/api/auth";
-import { getSurvey } from "@/utils/api/survey";
 
 
 
@@ -20,6 +19,7 @@ export default function LoginPage() {
     const {toast} = useToast();
     const auth = useAuth();
     const userLoggedIn = auth?.userLoggedIn;
+    const { reloadUser } = auth;
     const emailRef = useRef<HTMLInputElement | null>(null);
 
     const [email, setEmail] = useState("");
@@ -88,6 +88,7 @@ export default function LoginPage() {
             if (!isSigningIn) {
                 setIsSigningIn(true);
                 await doSignInWithEmailAndPassword(email, password);
+                await reloadUser();
 
                 const pingResponse = await ActivityPing();
                 if (!pingResponse.ok) {
@@ -95,15 +96,13 @@ export default function LoginPage() {
                         `Error ${pingResponse.code} when calling activityPing: ${pingResponse.error}`
                     );
                 }
-                const surveyResult = await getSurvey();
-                const completed = surveyResult.ok;
 
                 toast({
                     type: "success",
                     title: "Welcome back!",
                     description: "You’re now logged in.",
                 });
-                router.push(completed ? "/dashboard" : "../onboarding/createProfile");
+                router.push("/dashboard");
             }
         } catch (err: unknown) {
             console.error("Login error:", err);

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -20,9 +20,9 @@ export default function AppLayout({
 
   useEffect(() => {
     if (!loading && !userLoggedIn) {
-      router.push("/authentication?toast=not-signed-in");
+      router.replace("/authentication?toast=not-signed-in");
     } else if (!loading && userLoggedIn && isReady && requiredRoute) {
-      router.push(requiredRoute);
+      router.replace(requiredRoute);
     }
   }, [loading, userLoggedIn, isReady, requiredRoute, router]);
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@
 import Navbar from "@/components/navigation/navBar";
 import Sidebar from "@/components/navigation/sideBar";
 import { useAuth } from "@/contexts/authContext";
+import { useOnboardingRouting } from "@/hooks/useOnboardingRouting";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import LoadingSpinner from "@/components/LoadingSpinner";
@@ -14,15 +15,18 @@ export default function AppLayout({
   children: React.ReactNode;
 }) {
   const { userLoggedIn, loading } = useAuth();
+  const { requiredRoute, isLoading, isReady } = useOnboardingRouting();
   const router = useRouter();
 
   useEffect(() => {
     if (!loading && !userLoggedIn) {
       router.push("/authentication?toast=not-signed-in");
+    } else if (!loading && userLoggedIn && isReady && requiredRoute) {
+      router.push(requiredRoute);
     }
-  }, [loading, userLoggedIn, router]);
+  }, [loading, userLoggedIn, isReady, requiredRoute, router]);
 
-  if (loading) {
+  if (loading || isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-black">
         <LoadingSpinner size="lg" />
@@ -30,7 +34,7 @@ export default function AppLayout({
     );
   }
 
-  if (!userLoggedIn) {
+  if (!userLoggedIn || requiredRoute) {
     return null;
   }
 

--- a/src/app/onboarding/createProfile/page.tsx
+++ b/src/app/onboarding/createProfile/page.tsx
@@ -116,7 +116,7 @@ export default function CreateProfilePage() {
 	};
 
 	const handleNextStep = async () => {
-		if (!isFormValid) return;
+		if (!isFormValid || Object.values(profanityErrors).some(Boolean)) return;
 
 		setApiError(null);
 		setIsLoading(true);

--- a/src/app/onboarding/createProfile/page.tsx
+++ b/src/app/onboarding/createProfile/page.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import Image from "next/image";
 import { isProfane } from "@/utils/profanity";
 import NextStepButton from "../../../components/NextStepButton";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import ProgressHeader from "../../../components/ProgressHeader";
 import { useRef, useState, useEffect } from "react"; // mostly only for the profile picture
 import { DatePicker } from "../../../components/DatePicker";
@@ -11,9 +11,14 @@ import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { createProfile } from "@/utils/api/profile";
 import { Gender, Classification } from "@/types/profile";
 import { useOnboarding } from "@/contexts/onboardingContext";
+import { majors } from "@/constants/majors";
+import { useToast } from "@/components/ui/ToastProvider";
 
 export default function CreateProfilePage() {
 	const router = useRouter();
+    const searchParams = useSearchParams();
+    const { toast } = useToast();
+    const toastShownRef = useRef(false);
 	const { markProfileCompleted } = useOnboarding();
 	const [firstName, setFirstName] = useState("");
 	const [lastName, setLastName] = useState("");
@@ -43,6 +48,17 @@ export default function CreateProfilePage() {
 		});
 		return () => unsubscribe();
 	}, []);
+
+	useEffect(() => {
+		if (!toastShownRef.current && searchParams.get("toast") === "needs-profile") {
+			toast({
+				type: "info",
+				title: "Profile Required",
+				description: "Please complete your profile details.",
+			});
+			toastShownRef.current = true;
+		}
+	}, [searchParams, toast]);
 
 	// Bio character limit
 	const BIO_CHAR_LIMIT = 250;
@@ -211,58 +227,12 @@ export default function CreateProfilePage() {
 								<option value="" disabled>
 									Select an option...
 								</option>
-
-								<option value="biomedical-engineering">Biomedical Engineering</option>
-								<option value="computer-engineering">Computer Engineering</option>
-								<option value="computer-science">Computer Science</option>
-								<option value="data-science">Data Science</option>
-								<option value="electrical-engineering">Electrical Engineering</option>
-								<option value="mechanical-engineering">Mechanical Engineering</option>
-								<option value="software-engineering">Software Engineering</option>
-
-								<option value="accounting">Accounting</option>
-								<option value="business-administration">Business Administration</option>
-								<option value="business-analytics">Business Analytics</option>
-								<option value="finance">Finance</option>
-								<option value="global-business">Global Business</option>
-								<option value="healthcare-management">Healthcare Management</option>
-								<option value="human-resource-management">Human Resource Management</option>
-								<option value="information-technology-systems">Information Technology and Systems</option>
-								<option value="marketing">Marketing</option>
-								<option value="supply-chain-management">Supply Chain Management</option>
-
-								<option value="animation-games">Animation and Games</option>
-								<option value="arts-technology-emerging-communication">Arts, Technology, and Emerging Communication (ATEC)</option>
-								<option value="art-history">Art History</option>
-								<option value="history">History</option>
-								<option value="interdisciplinary-studies">Interdisciplinary Studies</option>
-								<option value="literature">Literature</option>
-								<option value="philosophy">Philosophy</option>
-								<option value="visual-performing-arts">Visual and Performing Arts</option>
-
-								<option value="child-learning-development">Child Learning and Development</option>
-								<option value="cognitive-science">Cognitive Science</option>
-								<option value="neuroscience">Neuroscience</option>
-								<option value="psychology">Psychology</option>
-								<option value="speech-language-hearing">Speech, Language, and Hearing Sciences</option>
-
-								<option value="criminology-criminal-justice">Criminology and Criminal Justice</option>
-								<option value="economics">Economics</option>
-								<option value="geospatial-information-sciences">Geospatial Information Sciences</option>
-								<option value="international-political-economy">International Political Economy</option>
-								<option value="political-science">Political Science</option>
-								<option value="public-affairs">Public Affairs</option>
-								<option value="public-policy">Public Policy</option>
-								<option value="sociology">Sociology</option>
-
-								<option value="actuarial-science">Actuarial Science</option>
-								<option value="biochemistry">Biochemistry</option>
-								<option value="biology">Biology</option>
-								<option value="chemistry">Chemistry</option>
-								<option value="geosciences">Geosciences</option>
-								<option value="mathematics">Mathematics</option>
-								<option value="molecular-biology">Molecular Biology</option>
-								<option value="physics">Physics</option>
+                                
+								{majors.map((majorOption) => (
+									<option key={majorOption.value} value={majorOption.value}>
+										{majorOption.label}
+									</option>
+								))}
 							</select>
 							<svg
 								className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none"

--- a/src/app/onboarding/createProfile/page.tsx
+++ b/src/app/onboarding/createProfile/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 import Image from "next/image";
-import { Filter } from "bad-words";
+import { isProfane } from "@/utils/profanity";
 import NextStepButton from "../../../components/NextStepButton";
 import { useRouter } from "next/navigation";
 import ProgressHeader from "../../../components/ProgressHeader";
@@ -11,9 +11,6 @@ import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { createProfile } from "@/utils/api/profile";
 import { Gender, Classification } from "@/types/profile";
 import { useOnboarding } from "@/contexts/onboardingContext";
-
-// profanity filter
-const filter = new Filter();
 
 export default function CreateProfilePage() {
 	const router = useRouter();
@@ -30,7 +27,11 @@ export default function CreateProfilePage() {
 	// API state
 	const [isLoading, setIsLoading] = useState(false);
 	const [apiError, setApiError] = useState<string | null>(null);
-	const [profanityError, setProfanityError] = useState<string | null>(null);
+	const [profanityErrors, setProfanityErrors] = useState({
+		firstName: false,
+		lastName: false,
+		bio: false,
+	});
 
 	// get user email from firebase auth
 	useEffect(() => {
@@ -60,11 +61,21 @@ export default function CreateProfilePage() {
 	};
 
 	const handleFirstNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setFirstName(e.target.value);
+		const value = e.target.value;
+		setFirstName(value);
+		setProfanityErrors((prev) => ({
+			...prev,
+			firstName: isProfane(value),
+		}));
 	};
 
 	const handleLastNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setLastName(e.target.value);
+		const value = e.target.value;
+		setLastName(value);
+		setProfanityErrors((prev) => ({
+			...prev,
+			lastName: isProfane(value),
+		}));
 	};
 
 	const handleMajorChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -81,15 +92,10 @@ export default function CreateProfilePage() {
 			setBio(value);
 			
 			// check for profanity
-			if (filter.isProfane(value)) {
-				setProfanityError("Profanity is not allowed in your bio.");
-			} else {
-				setProfanityError(null);
-			}
-
-            // clean as well bc u can bypass it
-            // ex: poop gets caught but poopoo doesn't idk y poop is on there but now poop will turn to ****
-            setBio(filter.clean(value));
+			setProfanityErrors((prev) => ({
+				...prev,
+				bio: isProfane(value),
+			}));
 		}
 	};
 
@@ -142,20 +148,26 @@ export default function CreateProfilePage() {
 							<input
 								type="text"
 								placeholder="Jane"
-								className={inputStyle}
+								className={`${inputStyle} ${profanityErrors.firstName ? "border-red-500 focus:ring-red-500" : ""}`}
 								value={firstName}
 								onChange={handleFirstNameChange}
 							/>
+							{profanityErrors.firstName && (
+								<p className="text-red-500 text-[10px] mt-1">Profanity is not allowed.</p>
+							)}
 						</div>
 						<div className="w-1/2">
 							<h1 className="text-black font-medium text-sm mb-2">Last Name</h1>
 							<input
 								type="text"
 								placeholder="Kelper"
-								className={inputStyle}
+								className={`${inputStyle} ${profanityErrors.lastName ? "border-red-500 focus:ring-red-500" : ""}`}
 								value={lastName}
 								onChange={handleLastNameChange}
 							/>
+							{profanityErrors.lastName && (
+								<p className="text-red-500 text-[10px] mt-1">Profanity is not allowed.</p>
+							)}
 						</div>
 					</div>
 
@@ -341,7 +353,7 @@ export default function CreateProfilePage() {
 					<div className="relative">
 						<textarea
 							placeholder="Write your Bio here e.g your hobbies, interests etc"
-							className={`${inputStyle} resize-none h-32`}
+							className={`${inputStyle} resize-none h-32 ${profanityErrors.bio ? "border-red-500 focus:ring-red-500" : ""}`}
 							value={bio}
 							onChange={handleBioChange}
 							maxLength={BIO_CHAR_LIMIT}
@@ -350,17 +362,17 @@ export default function CreateProfilePage() {
 							{bio.length}/{BIO_CHAR_LIMIT}
 						</div>
 					</div>
-					{profanityError && (
-						<p className="text-red-500 text-xs mt-1">{profanityError}</p>
+					{profanityErrors.bio && (
+						<p className="text-red-500 text-xs mt-1">Profanity is not allowed in your bio.</p>
 					)}
 				</div>
 
 				{/* Next Step Button */}
 				<div className="flex justify-center">
 					<NextStepButton
-						className={`mt-7 ${(!isFormValid || isLoading || !!profanityError) ? "opacity-50 cursor-not-allowed" : ""}`}
+						className={`mt-7 ${(!isFormValid || isLoading || Object.values(profanityErrors).some(Boolean)) ? "opacity-50 cursor-not-allowed" : ""}`}
 						onClick={handleNextStep}
-						disabled={!isFormValid || isLoading || !!profanityError}
+						disabled={!isFormValid || isLoading || Object.values(profanityErrors).some(Boolean)}
 					/>
 					{apiError && (
 						<p className="text-red-500 text-sm text-center mt-2">{apiError}</p>

--- a/src/app/onboarding/createProfile/page.tsx
+++ b/src/app/onboarding/createProfile/page.tsx
@@ -9,8 +9,11 @@ import { DatePicker } from "../../../components/DatePicker";
 import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { createProfile } from "@/utils/api/profile";
 import { Gender, Classification } from "@/types/profile";
+import { useOnboarding } from "@/contexts/onboardingContext";
+
 export default function CreateProfilePage() {
 	const router = useRouter();
+	const { markProfileCompleted } = useOnboarding();
 	const [firstName, setFirstName] = useState("");
 	const [lastName, setLastName] = useState("");
 	const [major, setMajor] = useState("");
@@ -98,6 +101,7 @@ export default function CreateProfilePage() {
 		}
 
 		setIsLoading(false);
+		markProfileCompleted(false);
 		router.push("/onboarding/uploadPictures");
 	};
 

--- a/src/app/onboarding/createProfile/page.tsx
+++ b/src/app/onboarding/createProfile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from "react";
 import Image from "next/image";
+import { Filter } from "bad-words";
 import NextStepButton from "../../../components/NextStepButton";
 import { useRouter } from "next/navigation";
 import ProgressHeader from "../../../components/ProgressHeader";
@@ -10,6 +11,9 @@ import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { createProfile } from "@/utils/api/profile";
 import { Gender, Classification } from "@/types/profile";
 import { useOnboarding } from "@/contexts/onboardingContext";
+
+// profanity filter
+const filter = new Filter();
 
 export default function CreateProfilePage() {
 	const router = useRouter();
@@ -26,6 +30,7 @@ export default function CreateProfilePage() {
 	// API state
 	const [isLoading, setIsLoading] = useState(false);
 	const [apiError, setApiError] = useState<string | null>(null);
+	const [profanityError, setProfanityError] = useState<string | null>(null);
 
 	// get user email from firebase auth
 	useEffect(() => {
@@ -71,8 +76,20 @@ export default function CreateProfilePage() {
 	};
 
 	const handleBioChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-		if (e.target.value.length <= BIO_CHAR_LIMIT) {
-			setBio(e.target.value);
+		const value = e.target.value;
+		if (value.length <= BIO_CHAR_LIMIT) {
+			setBio(value);
+			
+			// check for profanity
+			if (filter.isProfane(value)) {
+				setProfanityError("Profanity is not allowed in your bio.");
+			} else {
+				setProfanityError(null);
+			}
+
+            // clean as well bc u can bypass it
+            // ex: poop gets caught but poopoo doesn't idk y poop is on there but now poop will turn to ****
+            setBio(filter.clean(value));
 		}
 	};
 
@@ -323,7 +340,7 @@ export default function CreateProfilePage() {
 					<h1 className="text-black font-medium text-sm mb-2">Bio</h1>
 					<div className="relative">
 						<textarea
-							placeholder="Write your Bio here e.g your hobbies, interests ETC"
+							placeholder="Write your Bio here e.g your hobbies, interests etc"
 							className={`${inputStyle} resize-none h-32`}
 							value={bio}
 							onChange={handleBioChange}
@@ -333,14 +350,17 @@ export default function CreateProfilePage() {
 							{bio.length}/{BIO_CHAR_LIMIT}
 						</div>
 					</div>
+					{profanityError && (
+						<p className="text-red-500 text-xs mt-1">{profanityError}</p>
+					)}
 				</div>
 
 				{/* Next Step Button */}
 				<div className="flex justify-center">
 					<NextStepButton
-						className={`mt-7 ${(!isFormValid || isLoading) ? "opacity-50 cursor-not-allowed" : ""}`}
+						className={`mt-7 ${(!isFormValid || isLoading || !!profanityError) ? "opacity-50 cursor-not-allowed" : ""}`}
 						onClick={handleNextStep}
-						disabled={!isFormValid || isLoading}
+						disabled={!isFormValid || isLoading || !!profanityError}
 					/>
 					{apiError && (
 						<p className="text-red-500 text-sm text-center mt-2">{apiError}</p>

--- a/src/app/onboarding/housing/page.tsx
+++ b/src/app/onboarding/housing/page.tsx
@@ -9,6 +9,7 @@ import {useSearchParams, useRouter} from "next/navigation";
 import {loadOnboardingData, updateOnboardingData, clearOnboardingData} from "@/utils/onboardingStorage";
 import PriceRangeSlider from "@/components/PriceRangeSlider";
 import {submitSurvey, updateSurvey} from "@/utils/api/survey";
+import { useOnboarding } from "@/contexts/onboardingContext";
 
 function buildSurveyPayload(raw: any) {
   // 1) Start with backend-friendly defaults
@@ -73,6 +74,7 @@ const sendOnboardingData = async () => {
 
 function OnCampusUI() {
 	const router = useRouter();
+	const { markSurveyCompleted } = useOnboarding();
 	const handleNextStep = async () => {
 		const result = await sendOnboardingData();
 
@@ -81,6 +83,7 @@ function OnCampusUI() {
 			return;
 		}
 
+		markSurveyCompleted();
 		router.push("/dashboard"); // placeholder is fine for now
 	};
 
@@ -318,6 +321,7 @@ function OnCampusUI() {
 
 function OffCampusUI() {
 	const router = useRouter();
+	const { markSurveyCompleted } = useOnboarding();
 	const handleNextStep = async () => {
 		const result = await sendOnboardingData();
 
@@ -326,6 +330,7 @@ function OffCampusUI() {
 			return;
 		}
 
+		markSurveyCompleted();
 		router.push("/dashboard"); // placeholder is fine for now
 	};
 

--- a/src/app/onboarding/lifestylePreferences/page.tsx
+++ b/src/app/onboarding/lifestylePreferences/page.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { useState, useEffect} from "react";
 import LifestylePreferencesCard from "@/components/LifestylePreferencesCard";
 import NextStepButton from "@/components/NextStepButton";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import ProgressHeader from "@/components/ProgressHeader";
+import { useToast } from "@/components/ui/ToastProvider";
+import { useRef } from "react";
 import {
   loadOnboardingData,
   updateOnboardingData,
@@ -12,6 +14,9 @@ import {
 
 export default function LifestylePreferencesPage() {
 	const router = useRouter();
+	const searchParams = useSearchParams();
+	const { toast } = useToast();
+	const toastShownRef = useRef(false);
 
 	const [selectedWakeupTime, setSelectedWakeupTime] = useState<string | null>(
 		null
@@ -32,6 +37,17 @@ export default function LifestylePreferencesPage() {
       setSelectedNoiseTolerance(saved.noise_tolerance ?? null);
     setHydrated(true);
   }, []);
+
+	useEffect(() => {
+		if (!toastShownRef.current && searchParams.get("toast") === "needs-survey") {
+			toast({
+				type: "info",
+				title: "Survey Required",
+				description: "Please complete the survey to finish your onboarding.",
+			});
+			toastShownRef.current = true;
+		}
+	}, [searchParams, toast]);
 
 	
 	useEffect(() => {

--- a/src/app/onboarding/uploadPictures/page.tsx
+++ b/src/app/onboarding/uploadPictures/page.tsx
@@ -11,9 +11,14 @@ import ImageUpload from "@/components/imageHandling/imageUpload";
 import ProfileCardPreview from "@/components/cardComponent/ProfileCardPreview";
 import { UserProfile } from "@/types/userProfile";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import { useOnboarding } from "@/contexts/onboardingContext";
+
+export const MIN_PHOTOS = 3;
+export const MAX_PHOTOS = 5;
 
 export default function UploadPicturesPage() {
 	const router = useRouter();
+	const { markPictureUploaded } = useOnboarding();
 
 	const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
 	const [initialLoading, setInitialLoading] = useState(true);
@@ -28,9 +33,6 @@ export default function UploadPicturesPage() {
 	const [compressionError, setCompressionError] = useState<string | null>(null);
 	const [apiError, setApiError] = useState<string | null>(null);
 	const [isLoading, setIsLoading] = useState(false);
-
-	const MIN_PHOTOS = 3;
-	const MAX_PHOTOS = 5;
 
 	useEffect(() => {
 		const fetchUser = async () => {
@@ -179,6 +181,7 @@ export default function UploadPicturesPage() {
 		setIsLoading(true);
 
 		setIsLoading(false);
+		markPictureUploaded();
 		router.push("/onboarding/lifestylePreferences");
 	};
 

--- a/src/app/onboarding/uploadPictures/page.tsx
+++ b/src/app/onboarding/uploadPictures/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useRef, useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import ProgressHeader from "@/components/ProgressHeader";
 import NextStepButton from "@/components/NextStepButton";
 import { fetchCurrentUser } from "@/utils/api/auth";
@@ -12,12 +12,15 @@ import ProfileCardPreview from "@/components/cardComponent/ProfileCardPreview";
 import { UserProfile } from "@/types/userProfile";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { useOnboarding } from "@/contexts/onboardingContext";
+import { useToast } from "@/components/ui/ToastProvider";
 
-export const MIN_PHOTOS = 3;
-export const MAX_PHOTOS = 5;
+import { MIN_PHOTOS, MAX_PHOTOS } from "@/constants/onboarding";
 
 export default function UploadPicturesPage() {
 	const router = useRouter();
+	const searchParams = useSearchParams();
+	const { toast } = useToast();
+	const toastShownRef = useRef(false);
 	const { markPictureUploaded } = useOnboarding();
 
 	const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
@@ -52,6 +55,17 @@ export default function UploadPicturesPage() {
 		};
 		fetchUser();
 	}, []);
+
+	useEffect(() => {
+		if (!toastShownRef.current && searchParams.get("toast") === "needs-pictures") {
+			toast({
+				type: "info",
+				title: "Photos Required",
+				description: `Please upload at least ${MIN_PHOTOS} photos to continue to the dashboard.`,
+			});
+			toastShownRef.current = true;
+		}
+	}, [searchParams, toast]);
 
 	const [dropWarning, setDropWarning] = useState<string | null>(null);
 	const [isDragOver, setIsDragOver] = useState(false);

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,18 +1,21 @@
 "use client";
 
 import {AuthProvider} from "@/contexts/authContext";
+import {OnboardingProvider} from "@/contexts/onboardingContext";
 import ScreenBlocker from "@/components/ScreenBlocker";
 import {ToastProvider} from "@/components/ui/ToastProvider";
 
 export default function Providers({children}: { children: React.ReactNode }) {
     return (
         <AuthProvider>
-            <ToastProvider>
-                <div className="hidden md:block">{children}</div>
-                <div className="block md:hidden">
-                    <ScreenBlocker/>
-                </div>
-            </ToastProvider>
+            <OnboardingProvider>
+                <ToastProvider>
+                    <div className="hidden md:block">{children}</div>
+                    <div className="block md:hidden">
+                        <ScreenBlocker/>
+                    </div>
+                </ToastProvider>
+            </OnboardingProvider>
         </AuthProvider>
     );
 }

--- a/src/components/NextStepButton.tsx
+++ b/src/components/NextStepButton.tsx
@@ -22,7 +22,6 @@ const NextStepButton: React.FC<NextStepButtonProps> = ({
 				py-3 px-6 rounded-full text-white font-semibold text-lg
 				h-12 w-100
 				shadow-lg
-				cursor-pointer
 				transition-all duration-200 ease-in-out
         		overflow-visible
 					${

--- a/src/constants/onboarding.ts
+++ b/src/constants/onboarding.ts
@@ -1,0 +1,2 @@
+export const MIN_PHOTOS = 3;
+export const MAX_PHOTOS = 5;

--- a/src/contexts/authContext/index.tsx
+++ b/src/contexts/authContext/index.tsx
@@ -1,13 +1,14 @@
 "use client";
 import { onAuthStateChanged, User } from "firebase/auth";
 import { auth } from "../../firebase/firebase";
-import React, { useContext, useState, useEffect, createContext } from "react";
+import React, { useContext, useState, useEffect, createContext, useCallback } from "react";
 
 // Define what your AuthContext provides
 interface AuthContextType {
   currentUser: User | null;
   userLoggedIn: boolean;
   loading: boolean;
+  reloadUser: () => Promise<void>;
 }
 
 // Create context with correct type
@@ -42,10 +43,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setLoading(false);
   }
 
+  // login page can call after sign in so user context is fresh
+  const reloadUser = useCallback(async () => {
+    if (auth.currentUser) {
+      await auth.currentUser.reload();
+      const refreshedUser = auth.currentUser;
+      setCurrentUser(refreshedUser ? { ...refreshedUser } : null);
+      setUserLoggedIn(!!refreshedUser);
+    }
+  }, []);
+
   const value: AuthContextType = {
     currentUser,
     userLoggedIn,
     loading,
+    reloadUser,
   };
 
   return (

--- a/src/contexts/authContext/index.tsx
+++ b/src/contexts/authContext/index.tsx
@@ -34,7 +34,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   async function initializeUser(user: User | null) {
     if (user) {
-      setCurrentUser({ ...user });
+      setCurrentUser(user);
       setUserLoggedIn(true);
     } else {
       setCurrentUser(null);
@@ -48,7 +48,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (auth.currentUser) {
       await auth.currentUser.reload();
       const refreshedUser = auth.currentUser;
-      setCurrentUser(refreshedUser ? { ...refreshedUser } : null);
+      setCurrentUser(refreshedUser);
       setUserLoggedIn(!!refreshedUser);
     }
   }, []);

--- a/src/contexts/onboardingContext.tsx
+++ b/src/contexts/onboardingContext.tsx
@@ -36,6 +36,12 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     const [hasPicture, setHasPicture] = useState(false);
     const [hasSurvey, setHasSurvey] = useState(false);
 
+    const resetOnboardingState = useCallback(() => {
+        setHasProfile(false);
+        setHasPicture(false);
+        setHasSurvey(false);
+    }, []);
+
     useEffect(() => {
         let active = true;
 
@@ -54,6 +60,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
 
                     // If either critical call failed at the API level (e.g. 500), consider it an error
                     if (!profileRes.ok && profileRes.code !== "404") {
+                        resetOnboardingState();
                         setIsError(true);
                         return;
                     }
@@ -72,6 +79,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
                     if (surveyRes.ok && surveyRes.data) {
                         setHasSurvey(true);
                     } else if (!surveyRes.ok && surveyRes.code !== "404") {
+                        resetOnboardingState();
                         setIsError(true);
                     } else {
                         setHasSurvey(false);
@@ -79,6 +87,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
                 } catch (error) {
                     if (active) {
                         console.error("Failed to fetch onboarding status", error);
+                        resetOnboardingState();
                         setIsError(true);
                     }
                 } finally {
@@ -91,9 +100,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
                 if (active) {
                     setIsLoading(false);
                     setIsError(false);
-                    setHasProfile(false);
-                    setHasPicture(false);
-                    setHasSurvey(false);
+                    resetOnboardingState();
                 }
             }
         }

--- a/src/contexts/onboardingContext.tsx
+++ b/src/contexts/onboardingContext.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect } from "react";
+import { useAuth } from "./authContext";
+import { getProfile } from "@/utils/api/profile";
+import { getSurvey } from "@/utils/api/survey";
+import { MIN_PHOTOS } from "@/app/onboarding/uploadPictures/page";
+
+interface OnboardingContextType {
+    isLoading: boolean;
+    hasProfile: boolean;
+    hasPicture: boolean;
+    hasSurvey: boolean;
+    markProfileCompleted: (hasPic: boolean) => void;
+    markPictureUploaded: () => void;
+    markSurveyCompleted: () => void;
+}
+
+const OnboardingContext = createContext<OnboardingContextType | undefined>(undefined);
+
+export function useOnboarding(): OnboardingContextType {
+    const context = useContext(OnboardingContext);
+    if (!context) {
+        throw new Error("useOnboarding must be used within an OnboardingProvider");
+    }
+    return context;
+}
+
+export function OnboardingProvider({ children }: { children: React.ReactNode }) {
+    const { currentUser, userLoggedIn } = useAuth();
+  
+    const [isLoading, setIsLoading] = useState(true);
+    const [hasProfile, setHasProfile] = useState(false);
+    const [hasPicture, setHasPicture] = useState(false);
+    const [hasSurvey, setHasSurvey] = useState(false);
+
+    useEffect(() => {
+        async function checkOnboardingStatus() {
+            // Only check if logged in and email is verified.
+            if (userLoggedIn && currentUser?.emailVerified) {
+                setIsLoading(true);
+                try {
+                    const [profileRes, surveyRes] = await Promise.all([
+                        getProfile(currentUser.uid),
+                        getSurvey()
+                    ]);
+
+                    if (profileRes.ok && profileRes.data) {
+                        setHasProfile(true);
+                        setHasPicture(
+                            Array.isArray(profileRes.data.profile_picture_url) && 
+                            profileRes.data.profile_picture_url.length >= MIN_PHOTOS
+                        );
+                    } else {
+                        setHasProfile(false);
+                        setHasPicture(false);
+                    }
+
+                    if (surveyRes.ok && surveyRes.data) {
+                        setHasSurvey(true);
+                    } else {
+                        setHasSurvey(false);
+                    }
+                } catch (error) {
+                    console.error("Failed to fetch onboarding status", error);
+                } finally {
+                    setIsLoading(false);
+                }
+            } else {
+                // If not logged in or email not verified, stop loading.
+                setIsLoading(false);
+            }
+        }
+
+        checkOnboardingStatus();
+    }, [userLoggedIn, currentUser]);
+
+    const markProfileCompleted = (hasPic: boolean) => {
+        setHasProfile(true);
+        setHasPicture(hasPic);
+    };
+
+    const markPictureUploaded = () => {
+        setHasPicture(true);
+    };
+
+    const markSurveyCompleted = () => {
+        setHasSurvey(true);
+    };
+
+    const value: OnboardingContextType = {
+        isLoading,
+        hasProfile,
+        hasPicture,
+        hasSurvey,
+        markProfileCompleted,
+        markPictureUploaded,
+        markSurveyCompleted,
+    };
+
+    return (
+        <OnboardingContext.Provider value={value}>
+            {children}
+        </OnboardingContext.Provider>
+    );
+}

--- a/src/contexts/onboardingContext.tsx
+++ b/src/contexts/onboardingContext.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect } from "react";
+import React, { createContext, useContext, useState, useEffect, useMemo, useCallback } from "react";
 import { useAuth } from "./authContext";
 import { getProfile } from "@/utils/api/profile";
 import { getSurvey } from "@/utils/api/survey";
-import { MIN_PHOTOS } from "@/app/onboarding/uploadPictures/page";
+import { MIN_PHOTOS } from "@/constants/onboarding";
 
 interface OnboardingContextType {
     isLoading: boolean;
+    isError: boolean;
     hasProfile: boolean;
     hasPicture: boolean;
     hasSurvey: boolean;
@@ -30,20 +31,32 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     const { currentUser, userLoggedIn } = useAuth();
   
     const [isLoading, setIsLoading] = useState(true);
+    const [isError, setIsError] = useState(false);
     const [hasProfile, setHasProfile] = useState(false);
     const [hasPicture, setHasPicture] = useState(false);
     const [hasSurvey, setHasSurvey] = useState(false);
 
     useEffect(() => {
+        let active = true;
+
         async function checkOnboardingStatus() {
             // Only check if logged in and email is verified.
             if (userLoggedIn && currentUser?.emailVerified) {
                 setIsLoading(true);
+                setIsError(false);
                 try {
                     const [profileRes, surveyRes] = await Promise.all([
                         getProfile(currentUser.uid),
                         getSurvey()
                     ]);
+
+                    if (!active) return;
+
+                    // If either critical call failed at the API level (e.g. 500), consider it an error
+                    if (!profileRes.ok && profileRes.code !== "404") {
+                        setIsError(true);
+                        return;
+                    }
 
                     if (profileRes.ok && profileRes.data) {
                         setHasProfile(true);
@@ -58,45 +71,72 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
 
                     if (surveyRes.ok && surveyRes.data) {
                         setHasSurvey(true);
+                    } else if (!surveyRes.ok && surveyRes.code !== "404") {
+                        setIsError(true);
                     } else {
                         setHasSurvey(false);
                     }
                 } catch (error) {
-                    console.error("Failed to fetch onboarding status", error);
+                    if (active) {
+                        console.error("Failed to fetch onboarding status", error);
+                        setIsError(true);
+                    }
                 } finally {
-                    setIsLoading(false);
+                    if (active) {
+                        setIsLoading(false);
+                    }
                 }
             } else {
-                // If not logged in or email not verified, stop loading.
-                setIsLoading(false);
+                // If not logged in or email not verified stop loading and reset states
+                if (active) {
+                    setIsLoading(false);
+                    setIsError(false);
+                    setHasProfile(false);
+                    setHasPicture(false);
+                    setHasSurvey(false);
+                }
             }
         }
 
         checkOnboardingStatus();
+
+        return () => {
+            active = false;
+        };
     }, [userLoggedIn, currentUser]);
 
-    const markProfileCompleted = (hasPic: boolean) => {
+    const markProfileCompleted = useCallback((hasPic: boolean) => {
         setHasProfile(true);
         setHasPicture(hasPic);
-    };
+    }, []);
 
-    const markPictureUploaded = () => {
+    const markPictureUploaded = useCallback(() => {
         setHasPicture(true);
-    };
+    }, []);
 
-    const markSurveyCompleted = () => {
+    const markSurveyCompleted = useCallback(() => {
         setHasSurvey(true);
-    };
+    }, []);
 
-    const value: OnboardingContextType = {
+    const value: OnboardingContextType = useMemo(() => ({
         isLoading,
+        isError,
         hasProfile,
         hasPicture,
         hasSurvey,
         markProfileCompleted,
         markPictureUploaded,
         markSurveyCompleted,
-    };
+    }), [
+        isLoading,
+        isError,
+        hasProfile,
+        hasPicture,
+        hasSurvey,
+        markProfileCompleted,
+        markPictureUploaded,
+        markSurveyCompleted,
+    ]);
 
     return (
         <OnboardingContext.Provider value={value}>

--- a/src/hooks/useOnboardingRouting.ts
+++ b/src/hooks/useOnboardingRouting.ts
@@ -3,7 +3,7 @@ import { useOnboarding } from "@/contexts/onboardingContext";
 
 export function useOnboardingRouting() {
     const { currentUser, userLoggedIn } = useAuth();
-    const { isLoading: onboardingLoading, hasProfile, hasPicture, hasSurvey } = useOnboarding();
+    const { isLoading: onboardingLoading, isError, hasProfile, hasPicture, hasSurvey } = useOnboarding();
 
     // determines what page the user should be on
     const getRequiredRoute = (): string | null => {
@@ -12,6 +12,7 @@ export function useOnboardingRouting() {
         if (!currentUser.emailVerified) return "/authentication/verifyEmail";
 
         if (onboardingLoading) return null;
+        if (isError) throw new Error("Failed to load onboarding status. Please try refreshing.");
         if (!hasProfile) return "/onboarding/createProfile?toast=needs-profile";
         if (!hasPicture) return "/onboarding/uploadPictures?toast=needs-pictures";
         if (!hasSurvey) return "/onboarding/lifestylePreferences?toast=needs-survey";
@@ -35,6 +36,7 @@ export function useOnboardingRouting() {
     return {
         requiredRoute,
         isLoading: onboardingLoading,
+        isError,
         isReady: !onboardingLoading,
         isVerificationRequired,
         isOnboardingComplete

--- a/src/hooks/useOnboardingRouting.ts
+++ b/src/hooks/useOnboardingRouting.ts
@@ -1,0 +1,25 @@
+import { useAuth } from "@/contexts/authContext";
+import { useOnboarding } from "@/contexts/onboardingContext";
+
+export function useOnboardingRouting() {
+    const { currentUser, userLoggedIn } = useAuth();
+    const { isLoading, hasProfile, hasPicture, hasSurvey } = useOnboarding();
+
+    const getRequiredRoute = (): string | null => {
+        if (!userLoggedIn || !currentUser) return null;
+
+        if (!currentUser.emailVerified) return "/authentication/verifyEmail";
+
+        if (isLoading) return null;
+
+        if (!hasProfile) return "/onboarding/createProfile";
+        if (!hasPicture) return "/onboarding/uploadPictures";
+        if (!hasSurvey) return "/onboarding/lifestylePreferences";
+
+        return null;
+    };
+
+    const requiredRoute = getRequiredRoute();
+
+    return { requiredRoute, isLoading, isReady: !isLoading };
+}

--- a/src/hooks/useOnboardingRouting.ts
+++ b/src/hooks/useOnboardingRouting.ts
@@ -3,23 +3,40 @@ import { useOnboarding } from "@/contexts/onboardingContext";
 
 export function useOnboardingRouting() {
     const { currentUser, userLoggedIn } = useAuth();
-    const { isLoading, hasProfile, hasPicture, hasSurvey } = useOnboarding();
+    const { isLoading: onboardingLoading, hasProfile, hasPicture, hasSurvey } = useOnboarding();
 
+    // determines what page the user should be on
     const getRequiredRoute = (): string | null => {
         if (!userLoggedIn || !currentUser) return null;
 
         if (!currentUser.emailVerified) return "/authentication/verifyEmail";
 
-        if (isLoading) return null;
-
-        if (!hasProfile) return "/onboarding/createProfile";
-        if (!hasPicture) return "/onboarding/uploadPictures";
-        if (!hasSurvey) return "/onboarding/lifestylePreferences";
+        if (onboardingLoading) return null;
+        if (!hasProfile) return "/onboarding/createProfile?toast=needs-profile";
+        if (!hasPicture) return "/onboarding/uploadPictures?toast=needs-pictures";
+        if (!hasSurvey) return "/onboarding/lifestylePreferences?toast=needs-survey";
 
         return null;
     };
 
     const requiredRoute = getRequiredRoute();
 
-    return { requiredRoute, isLoading, isReady: !isLoading };
+    // Explicit flags to help components avoid guesswork
+    const isVerificationRequired = !!(userLoggedIn && currentUser && !currentUser.emailVerified);
+    const isOnboardingComplete = !!(
+        userLoggedIn &&
+        currentUser?.emailVerified &&
+        !onboardingLoading &&
+        hasProfile &&
+        hasPicture &&
+        hasSurvey
+    );
+
+    return {
+        requiredRoute,
+        isLoading: onboardingLoading,
+        isReady: !onboardingLoading,
+        isVerificationRequired,
+        isOnboardingComplete
+    };
 }

--- a/src/utils/profanity.ts
+++ b/src/utils/profanity.ts
@@ -1,0 +1,9 @@
+import { Filter } from "bad-words";
+
+const filter = new Filter();
+
+// checks if a string contains profanity
+export const isProfane = (text: string): boolean => {
+    if (!text) return false;
+    return filter.isProfane(text);
+};


### PR DESCRIPTION
## What changed
- Fixed onboarding routing so if u log out and log back in on any step it remembers where u need to be
- added basic profanity filter on bio, first name, and last name sections in create profile

## Why
- 

## How to test
1. go through the onboarding

## Screenshots (UI changes)
- N/A

## Checklist
- [x] PR title is conventional (feat:, fix:, chore:, docs:)
- [x] Tested locally
- [x] No secrets/credentials logged or committed
- [x] This PR is reasonably sized (if large, explained why)

## Notes for reviewers
- tested full end to end workflow and logging back in at each step to see if it works, it does
- profanity filter is still easily bypassable but its a cheap solution for now and prevents at least accidental profanity, if someone says something really bad they'll just get reported anyway
