### PR TITLE
Feat: Navbar uses User's PFP

### DIFF
--- a/src/components/navigation/ProfileAvatar.tsx
+++ b/src/components/navigation/ProfileAvatar.tsx
@@ -1,17 +1,30 @@
 "use client";
+import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { readCachedCurrentUser } from "@/utils/currentUserCache";
 
 export default function ProfileAvatar() {
     const router = useRouter();
+    const [src, setSrc] = useState<string>("/peechi_progress_2.svg");
+
+    useEffect(() => {
+        try {
+            const cached = readCachedCurrentUser();
+            const first = cached?.profile?.profile_picture_url?.[0];
+            if (first) setSrc(first);
+        } catch (e) {
+            // ignore and keep placeholder
+            console.warn("ProfileAvatar: no cached profile image; using placeholder", e);
+        }
+    }, []);
+
     return (
-        <button className="relative w-10 h-10 rounded-full overflow-hidden border border-gray-300 cursor-pointer hover:ring-2 hover:ring-primary-hover transition" onClick={() => router.push("/dashboard/profile")}>
-            <Image
-                src="/profile-pic-PH.png" // put this in /public
-                alt="User profile placeholder"
-                fill
-                className="object-cover"
-            />
+        <button
+            className="relative w-10 h-10 rounded-full overflow-hidden border border-gray-300 cursor-pointer hover:ring-2 hover:ring-primary-hover transition"
+            onClick={() => router.push("/dashboard/profile")}
+        >
+            <Image src={src} alt="User profile" fill className="object-cover" />
         </button>
     );
 }


### PR DESCRIPTION
## What changed
- Navbar Profile uses user pfp now

## Why
- I'm not sure. I kinda liked having Aastha's pfp there.

## How to test
Testing if your current 1st picture is the pfp.
1. Go to dashboard/profile pictures on the 2nd page and save whatever you want
2. Reload the page and it'll be the new navbar pfp

Testing the placeholder
1. Go to `onboarding.ts` and change the `MIN_PHOTOS` to 0
2. Remove all pictures from dashboard/profile pictures on the 2nd page and update profile
3. Reload page for current results

## Screenshots (UI changes)
- No pfp
<img width="1901" height="908" alt="image" src="https://github.com/user-attachments/assets/64357aee-f5ce-43fb-9eab-3b740044218d" />
- With pfp
<img width="1912" height="907" alt="image" src="https://github.com/user-attachments/assets/960e4408-1f92-4046-ad1e-b9e743625ab2" />



## Checklist
- [x] PR title is conventional (feat:, fix:, chore:, docs:)
- [x] Tested locally
- [x] No secrets/credentials logged or committed
- [x] This PR is reasonably sized (if large, explained why)

## Notes for reviewers
- 
