### PR TITLE
Fix: ProfileGallery API fetch

### DIFF
--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -179,7 +179,10 @@ export default function Profile() {
       <div className="flex flex-col justify-center items-center relative">
         <div className="w-[76%] min-h-180 bg-[#FFFFFF] rounded-2xl shadow-2xl ">
           <div className="mt-4 ml-6">
-            <ProfileGallery userId={userData.id} />
+            <ProfileGallery
+              userId={userData.id}
+              initialImages={userData.profile?.profile_picture_url}
+            />
           </div>
           <div className="grid grid-cols-2 gap-4 w-full p-4">
             <div className="text-md">

--- a/src/components/imageHandling/ProfileGallery.tsx
+++ b/src/components/imageHandling/ProfileGallery.tsx
@@ -3,17 +3,24 @@ import ImageDisplay from "./ImageDisplay";
 import LoadingSpinner from "../LoadingSpinner";
 import { fetchProfile } from "@/utils/api/profile";
 
-// const MAX_IMAGES = 5;
-
 interface ProfileGalleryProps {
   userId: string;
+  initialImages?: string[];
 }
 
-export default function ProfileGallery({ userId }: ProfileGalleryProps) {
-  const [images, setImages] = useState<string[]>([]);
+export default function ProfileGallery({ userId, initialImages }: ProfileGalleryProps) {
+  const [images, setImages] = useState<string[]>(initialImages ?? []);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (initialImages !== undefined) {
+      setImages(initialImages);
+      setLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+
     async function fetchProfileImages() {
       setLoading(true);
       try {
@@ -26,6 +33,8 @@ export default function ProfileGallery({ userId }: ProfileGalleryProps) {
         }
 
         const data = res.data;
+        if (!isMounted) return;
+
         if (
           !data ||
           !Array.isArray(data.profile_picture_url) ||
@@ -37,13 +46,18 @@ export default function ProfileGallery({ userId }: ProfileGalleryProps) {
         }
       } catch (error) {
         console.error("Failed to fetch profile images:", error);
-        setImages([]);
+        if (isMounted) setImages([]);
       } finally {
-        setLoading(false);
+        if (isMounted) setLoading(false);
       }
     }
+
     if (userId) fetchProfileImages();
-  }, [userId]);
+
+    return () => {
+      isMounted = false;
+    };
+  }, [initialImages, userId]);
 
   const handleImageChange = (newImageUrl: string, index?: number) => {
     setImages((prev) => {
@@ -70,8 +84,6 @@ export default function ProfileGallery({ userId }: ProfileGalleryProps) {
   };
 
   const profileImage = images[0];
-  // const featuredImages = images.slice(1, MAX_IMAGES);
-  // const nextFeaturedIndex = 1 + featuredImages.length;
 
   return (
     <div>
@@ -101,31 +113,6 @@ export default function ProfileGallery({ userId }: ProfileGalleryProps) {
             </span>
           )}
         </div>
-        {/* Removing featured images to match figma design, but the code is still here */}
-        {/* <div className="flex flex-col items-center">
-          <span className="mb-2 font-semibold text-sm self-start">
-            Featured Pictures
-          </span>
-          <div className="flex flex-row gap-4">
-            {featuredImages.map((img, idx) => (
-              <ImageDisplay
-                key={idx + 1}
-                imageUrl={img}
-                onImageChange={(url) => handleImageChange(url, idx + 1)}
-                deleteIndex={images.length > idx + 1 ? idx + 1 : undefined}
-                onDeleted={() => handleImageRemoved(idx + 1)}
-              />
-            ))}
-            {featuredImages.length < MAX_IMAGES - 1 && (
-              <ImageDisplay
-                key={nextFeaturedIndex}
-                imageUrl=""
-                variant="placeholder"
-                onImageChange={(url) => handleImageChange(url, nextFeaturedIndex)}
-              />
-            )}
-          </div>
-        </div> */}
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed
- `ProfileGallery` didn't receive any images and fetched images on its own. We already fetch on auth login, and cache in local storage. Changed it so that `dashboard/Profile` main calls `ProfileGallery` AND sends `initialImages` so `ProfileGallery` doesn't need to call backend on its own.
- Cleaned up some old comments and whitespace

## Why
- Reduce API calls

## How to test
1. Open app and travel around
2. Track backend logs


## Checklist
- [x] PR title is conventional (feat:, fix:, chore:, docs:)
- [x] Tested locally
- [x] No secrets/credentials logged or committed
- [x] This PR is reasonably sized (if large, explained why)

