### PR TITLE
- fixed issue where after verifying email doesn't reload properly

### DIFF
--- a/src/app/authentication/verifyEmail/page.tsx
+++ b/src/app/authentication/verifyEmail/page.tsx
@@ -105,6 +105,9 @@ export default function VerifyEmailPage() {
                 return;
             }
 
+            // Reload the Firebase user so emailVerified is up-to-date
+            await getAuth().currentUser?.reload();
+
             router.push("../authentication?created=1");
         } catch (err) {
             setError("Something went wrong. Please try again.");


### PR DESCRIPTION
## What changed
- fixed bug where verifying email didnt reload firebase user

## Why
- users would be stuck on the verify email page

## How to test
1. test creating an account and verifying ur email, check to see if the whole onboarding flow works properly
2. 

## Screenshots (UI changes)
- 

## Checklist
- [ ] PR title is conventional (feat:, fix:, chore:, docs:)
- [ ] Tested locally
- [ ] No secrets/credentials logged or committed
- [ ] This PR is reasonably sized (if large, explained why)

## Notes for reviewers
- 
