### PR TITLE
feat: school column error handling

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,10 @@ const nextConfig: NextConfig = {
                 protocol: 'https',
                 hostname: 'storage.googleapis.com',
             },
+            {
+                protocol: 'https',
+                hostname: 'firebasestorage.googleapis.com',
+            },
         ],
     },
 };

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -5,8 +5,8 @@ import Navbar from "@/components/navigation/navBar";
 import Sidebar from "@/components/navigation/sideBar";
 import { useAuth } from "@/contexts/authContext";
 import { useOnboardingRouting } from "@/hooks/useOnboardingRouting";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useEffect, useMemo } from "react";
 import LoadingSpinner from "@/components/LoadingSpinner";
 
 export default function AppLayout({
@@ -17,14 +17,21 @@ export default function AppLayout({
     const { userLoggedIn, loading } = useAuth();
     const { requiredRoute, isLoading, isReady } = useOnboardingRouting();
     const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    const currentFullPath = useMemo(() => {
+        const params = searchParams?.toString();
+        return pathname + (params ? `?${params}` : "");
+    }, [pathname, searchParams]);
 
     useEffect(() => {
         if (!loading && !userLoggedIn) {
             router.replace("/authentication?toast=not-signed-in");
-        } else if (!loading && userLoggedIn && isReady && requiredRoute) {
+        } else if (!loading && userLoggedIn && isReady && requiredRoute && requiredRoute !== currentFullPath) {
             router.replace(requiredRoute);
         }
-    }, [loading, userLoggedIn, isReady, requiredRoute, router]);
+    }, [loading, userLoggedIn, isReady, requiredRoute, router, currentFullPath]);
 
     if (loading || isLoading) {
         return (
@@ -34,7 +41,11 @@ export default function AppLayout({
         );
     }
 
-    if (!userLoggedIn || requiredRoute) {
+    if (!userLoggedIn) {
+        return null;
+    }
+
+    if (requiredRoute && requiredRoute !== currentFullPath) {
         return null;
     }
 

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
-import React, { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import React, { useEffect, useState, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { fetchCurrentUser } from "@/utils/api/auth";
 import { UserProfile } from "@/types/userProfile";
 import { useToast } from "@/components/ui/ToastProvider";
@@ -12,6 +12,8 @@ import UnsavedChangesDialog from "@/components/navigation/UnsavedChangesDialog";
 import { DatePicker } from "../../../components/DatePicker";
 import { majors } from "@/constants/majors";
 import { schools } from "@/constants/schools";
+import { useOnboarding } from "@/contexts/onboardingContext";
+import SchoolOnlyCard from "@/components/profile/SchoolOnlyCard";
 
 interface ProfileFormState {
   major: string;
@@ -26,7 +28,12 @@ export default function Profile() {
     const [user, setUser] = useState<UserProfile | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [schoolOnlyMode, setSchoolOnlyMode] = useState(false);
     const router = useRouter();
+    const searchParams = useSearchParams();
+    const { toast } = useToast();
+    const toastShownRef = useRef(false);
+    const { markSchoolSelected } = useOnboarding();
 
     const [major, setMajor] = useState("");
     const [school, setSchool] = useState("");
@@ -48,8 +55,6 @@ export default function Profile() {
     const BIO_CHAR_LIMIT = 250;
     const currentYear = new Date().getFullYear();
 
-    const { toast } = useToast();
-
     const isDirty =
     hasLoadedProfileData &&
     (major !== initialValues.major ||
@@ -69,7 +74,15 @@ export default function Profile() {
                     preferCache: true,
                     maxAgeMs: 5 * 60 * 1000,
                 });
-                if (!data.ok) throw new Error(data.error || "Failed to fetch profile");
+
+                if (!data.ok) {
+                    if (data.code === "428") {
+                        // Profile exists but school is missing
+                        setSchoolOnlyMode(true);
+                        return;
+                    }
+                    throw new Error(data.error || "Failed to fetch profile");
+                }
 
                 setUser(data.data);
                 // To cut out the T00:00:00 
@@ -103,8 +116,45 @@ export default function Profile() {
         fetchuser();
     }, [router]);
 
+    useEffect(() => {
+        if (!toastShownRef.current && searchParams.get("toast") === "needs-school") {
+            toast({
+                type: "info",
+                title: "School Required",
+                description: "Please select your school to complete your profile.",
+            });
+            toastShownRef.current = true;
+        }
+    }, [searchParams, toast]);
+
     const handleUpdateProfile = async () => {
         try {
+            if (schoolOnlyMode) {
+                if (!school) {
+                    toast({
+                        type: "error",
+                        title: "School required",
+                        description: "Please select your school.",
+                    });
+                    return;
+                }
+
+                const updateResult = await apiFetch("/api/profiles/update", {
+                    method: "PUT",
+                    body: { school },
+                });
+                if (!updateResult.ok)
+                    throw new Error(updateResult.error || "Failed to update profile");
+
+                markSchoolSelected();
+                toast({
+                    type: "success",
+                    title: "School updated",
+                    description: "Your school has been saved.",
+                });
+                return;
+            }
+
             if (!birthday) {
                 toast({
                     type: "error",
@@ -161,6 +211,16 @@ export default function Profile() {
 
     if (loading) return <div>Loading...</div>;
     if (error) return <div>Error: {error}</div>;
+    if (schoolOnlyMode) {
+        return (
+            <SchoolOnlyCard
+                school={school}
+                onSchoolChange={setSchool}
+                onSave={handleUpdateProfile}
+                disabled={!school}
+            />
+        );
+    }
     if (!user) return <div>No user data found</div>;
     const userData = user;
 

--- a/src/components/profile/SchoolOnlyCard.tsx
+++ b/src/components/profile/SchoolOnlyCard.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { schools } from "@/constants/schools";
+
+interface SchoolOnlyCardProps {
+    school: string;
+    onSchoolChange: (value: string) => void;
+    onSave: () => void;
+    disabled?: boolean;
+}
+
+export default function SchoolOnlyCard({
+    school,
+    onSchoolChange,
+    onSave,
+    disabled,
+}: SchoolOnlyCardProps) {
+    return (
+        <div className="flex flex-col items-center justify-center min-h-[60vh]">
+            <div className="bg-white rounded-lg shadow-2xl p-8 w-full max-w-md">
+                <h2 className="text-xl font-semibold mb-2">Select Your School</h2>
+                <p className="text-gray-600 mb-6">
+                    Please choose your school to complete your profile.
+                </p>
+                <div className="mb-6">
+                    <p className="font-medium text-sm mb-2">School</p>
+                    <div className="relative">
+                        <select
+                            name="school"
+                            className="w-full px-4 py-3 border border-[#FF9100] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#FF9100] bg-white appearance-none cursor-pointer"
+                            value={school}
+                            onChange={(e) => onSchoolChange(e.target.value)}
+                        >
+                            <option value="" disabled>Select an option...</option>
+                            {schools.map((schoolOption) => (
+                                <option key={schoolOption.value} value={schoolOption.value}>
+                                    {schoolOption.label}
+                                </option>
+                            ))}
+                        </select>
+                        <svg
+                            className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none"
+                            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                        >
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </div>
+                </div>
+                <button
+                    type="button"
+                    onClick={onSave}
+                    disabled={disabled}
+                    className={`w-full px-6 py-3 rounded-lg text-black font-medium shadow bg-linear-60 from-[#F28C00] to-[#FFC243] hover:from-[#d97706] hover:to-[#f59e0b] transition-all duration-200 ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+                >
+                    Save
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/contexts/onboardingContext.tsx
+++ b/src/contexts/onboardingContext.tsx
@@ -11,9 +11,11 @@ interface OnboardingContextType {
     hasProfile: boolean;
     hasPicture: boolean;
     hasSurvey: boolean;
+    needsSchool: boolean;
     markProfileCompleted: (hasPic: boolean) => void;
     markPictureUploaded: () => void;
     markSurveyCompleted: () => void;
+    markSchoolSelected: () => void;
 }
 
 const OnboardingContext = createContext<OnboardingContextType | undefined>(undefined);
@@ -34,11 +36,14 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     const [hasProfile, setHasProfile] = useState(false);
     const [hasPicture, setHasPicture] = useState(false);
     const [hasSurvey, setHasSurvey] = useState(false);
+    const [needsSchool, setNeedsSchool] = useState(false);
+    const [refreshTrigger, setRefreshTrigger] = useState(0);
 
     const resetOnboardingState = useCallback(() => {
         setHasProfile(false);
         setHasPicture(false);
         setHasSurvey(false);
+        setNeedsSchool(false);
     }, []);
 
     // prevents re firing when firebase replaces user
@@ -59,7 +64,20 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
 
                     if (!active) return;
 
-                    if (!res.ok || !res.data) {
+                    if (!res.ok) {
+                        if (res.code === "428") { // auth.py: error code for if there isn't a school selected
+                            setNeedsSchool(true);
+                            setHasProfile(true);
+                            return;
+                        }
+                        console.error(`Onboarding fetch failed: code=${res.code}, error=${res.error}`);
+                        resetOnboardingState();
+                        setIsError(true);
+                        return;
+                    }
+
+                    if (!res.data) {
+                        console.error("Onboarding fetch succeeded but response body was empty");
                         resetOnboardingState();
                         setIsError(true);
                         return;
@@ -72,6 +90,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
                     setHasProfile(profileDone);
                     setHasPicture(picturesDone);
                     setHasSurvey(userData.survey_done);
+                    setNeedsSchool(false);
                 } catch (error) {
                     if (active) {
                         console.error("Failed to fetch onboarding status", error);
@@ -99,7 +118,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
             active = false;
         };
         // uid + emailVerified are primitives so this only re-runs on real identity changes.
-    }, [userLoggedIn, uid, emailVerified, resetOnboardingState]);
+    }, [userLoggedIn, uid, emailVerified, resetOnboardingState, refreshTrigger]);
 
     const markProfileCompleted = useCallback((hasPic: boolean) => {
         setHasProfile(true);
@@ -114,24 +133,33 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
         setHasSurvey(true);
     }, []);
 
+    const markSchoolSelected = useCallback(() => {
+        setNeedsSchool(false);
+        setRefreshTrigger((c) => c + 1);
+    }, []);
+
     const value: OnboardingContextType = useMemo(() => ({
         isLoading,
         isError,
         hasProfile,
         hasPicture,
         hasSurvey,
+        needsSchool,
         markProfileCompleted,
         markPictureUploaded,
         markSurveyCompleted,
+        markSchoolSelected,
     }), [
         isLoading,
         isError,
         hasProfile,
         hasPicture,
         hasSurvey,
+        needsSchool,
         markProfileCompleted,
         markPictureUploaded,
         markSurveyCompleted,
+        markSchoolSelected,
     ]);
 
     return (

--- a/src/hooks/useOnboardingRouting.ts
+++ b/src/hooks/useOnboardingRouting.ts
@@ -3,7 +3,7 @@ import { useOnboarding } from "@/contexts/onboardingContext";
 
 export function useOnboardingRouting() {
     const { currentUser, userLoggedIn } = useAuth();
-    const { isLoading: onboardingLoading, isError, hasProfile, hasPicture, hasSurvey } = useOnboarding();
+    const { isLoading: onboardingLoading, isError, hasProfile, hasPicture, hasSurvey, needsSchool } = useOnboarding();
 
     // determines what page the user should be on
     const getRequiredRoute = (): string | null => {
@@ -13,6 +13,7 @@ export function useOnboardingRouting() {
 
         if (onboardingLoading) return null;
         if (isError) throw new Error("Failed to load onboarding status. Please try refreshing.");
+        if (needsSchool) return "/dashboard/profile?toast=needs-school";
         if (!hasProfile) return "/onboarding/createProfile?toast=needs-profile";
         if (!hasPicture) return "/onboarding/uploadPictures?toast=needs-pictures";
         if (!hasSurvey) return "/onboarding/lifestylePreferences?toast=needs-survey";


### PR DESCRIPTION
# Files changed
- src/contexts/onboardingContext.tsx
- src/hooks/useOnboardingRouting.ts
- src/app/dashboard/layout.tsx
- src/app/dashboard/profile/page.tsx
- src/components/profile/SchoolOnlyCard.tsx (new)

# Problem
`GET /api/auth/me` returns a 428 with code SCHOOL_REQUIRED when a user has an existing profile with a NULL school (me lol). The app crashes since the school field is required.  

# Fix
- Redirect the user to select a school

# Changes
- `onboardingContext.tsx` — Added needsSchool state. On a 428 response, sets needsSchool = true and hasProfile = true (profile exists but incomplete) instead of treating it as an error. Added markSchoolSelected() callback that clears the flag and triggers a re-fetch to re-evaluate onboarding status.
- `useOnboardingRouting.ts` — Added needsSchool routing check: if set, redirect to `/dashboard/profile?toast=needs-school`.
- `dashboard/layout.tsx` — Added `usePathname`/`useSearchParams` to compare the current URL against `requiredRoute`. The layout now only blocks rendering or redirects when the user isn't already on the required route. This prevents a redirect loop when `requiredRoute` is a dashboard sub-route like `/dashboard/profile`.
- `dashboard/profile/page.tsx` — Added schoolOnlyMode state. When `/api/auth/me` returns 428, enters school-only mode (shows just the school dropdown instead of the full profile editor). Sends PUT /api/profiles/update with only { school }, preserving all other existing profile fields. Calls markSchoolSelected() on success so onboarding re-evaluates.
- `SchoolOnlyCard.tsx (new)` — Extracted the school-only selection UI into a focused, reusable component with a school dropdown and Save button.